### PR TITLE
Add RecipeError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tower-http",
 ]
@@ -605,6 +606,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ askama = "0.13.1"
 mime = "0.3.17"
 serde_json = "1.0.140"
 serde = { version = "1.0.219", features = ["derive"] }
+thiserror = "2.0.12"
 
 [dependencies.tower-http]
 version = "0.6.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,10 @@
+extern crate serde_json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RecipeError {
+    #[error("could not find recipes file: {0}")]
+    RecipesNotFound(#[from] std::io::Error),
+    #[error("could not read recipes file: {0}")]
+    RecipesMisformat(#[from] serde_json::Error),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
+mod error;
 mod recipe;
 mod templates;
 
+use error::*;
 use recipe::*;
 use templates::*;
 
 extern crate mime;
 use axum::{self, extract::State, response, routing};
+use std::sync::Arc;
 use tokio::{net, sync::RwLock};
 use tower_http::services;
-use std::sync::Arc;
 
 struct AppState {
     recipes: Vec<Recipe>,
@@ -25,8 +27,7 @@ async fn get_recipe(State(app_state): State<Arc<RwLock<AppState>>>) -> response:
 
 async fn serve() -> Result<(), Box<dyn std::error::Error>> {
     let recipes = read_recipes("assets/static/recipes.json")?;
-    let state = Arc::new(RwLock::new(AppState{recipes}));
-
+    let state = Arc::new(RwLock::new(AppState { recipes }));
 
     let mime_favicon = "image/vnd.microsoft.icon".parse().unwrap();
     let app = axum::Router::new()
@@ -34,17 +35,11 @@ async fn serve() -> Result<(), Box<dyn std::error::Error>> {
         // NOTE: axum talks to tower-http
         .route_service(
             "/recipe.css",
-            services::ServeFile::new_with_mime(
-                "assets/static/recipe.css",
-                &mime::TEXT_CSS_UTF_8,
-            ),
+            services::ServeFile::new_with_mime("assets/static/recipe.css", &mime::TEXT_CSS_UTF_8),
         )
         .route_service(
             "/favicon.ico",
-            services::ServeFile::new_with_mime(
-                "assets/static/favicon.ico",
-                &mime_favicon,
-            ),
+            services::ServeFile::new_with_mime("assets/static/favicon.ico", &mime_favicon),
         )
         .with_state(state);
     let listener = net::TcpListener::bind("127.0.0.1:3000").await?;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,15 +1,16 @@
-use std::path::Path;
+use crate::RecipeError;
 use serde::Deserialize;
+use std::path::Path;
 
 #[derive(Deserialize)]
 pub struct Recipe {
     pub title: String,
-    pub ingredients : Vec<String>,
+    pub ingredients: Vec<String>,
     pub instructions: Vec<String>,
     pub source: String,
 }
 
-pub fn read_recipes<P: AsRef<Path>>(recipes_path: P) -> Result<Vec<Recipe>, Box<dyn std::error::Error>> {
+pub fn read_recipes<P: AsRef<Path>>(recipes_path: P) -> Result<Vec<Recipe>, RecipeError> {
     let f = std::fs::File::open(recipes_path.as_ref())?;
     let recipes = serde_json::from_reader(f)?;
     Ok(recipes)


### PR DESCRIPTION
# Overview

Add RecipeError to the project for file read errors and deserialization errors. 
Use `cargo fmt` to format codebase.