### PR TITLE
Tags & ID Query String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2000,6 +2001,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ features = ["fs", "trace"]
 [dependencies.sqlx]
  version = "0.8.5"
  features = ["runtime-tokio", "sqlite", "derive", "macros", "migrate", "chrono", "json"]
+
+[dependencies.tokio-stream]
+version = "0.1.17"
+features = ["full"]

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -7,6 +7,11 @@
 </head>
 <body>
     <h1>Recipes</h1>
+    <form>
+        <label>Search By Tags (comma separated):</label>
+        <input type="text" name="tags"/>
+        <button type="submit">New Recipe</button>
+    </form>
     <div class="recipe">
         <h2>{{recipe.title}}</h2>
         <h3>Ingredients</h3>
@@ -21,7 +26,10 @@
                 <li>{{ step }}</li>
             {% endfor %}
         </ol>
+    </div>
+    <div class="info">
         <span class="">Recipe source: <a href="{{recipe.recipe_source}}">{{recipe.recipe_source}}</a></span><br/>
+        <span class="tags">Tags: {{tags}}</span>
     </div>
 </body>
 </html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,13 @@ extern crate log;
 extern crate fastrand;
 extern crate mime;
 
-use axum::{self, extract::State, response, routing};
+use axum::{self, extract::{Query, State}, http, response::{self, IntoResponse}, routing};
 use clap::Parser;
-use sqlx::SqlitePool;
+use serde::Deserialize;
+use sqlx::{Row, SqlitePool};
 use std::sync::Arc;
 use tokio::{net, sync::RwLock};
+use tokio_stream::StreamExt;
 use tower_http::{services, trace};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -29,30 +31,122 @@ struct AppState {
     current_recipe: Recipe,
 }
 
-async fn get_recipe(State(app_state): State<Arc<RwLock<AppState>>>) -> response::Html<String> {
-    let mut app_state = app_state.write().await;
-    let db = &app_state.db;
+#[derive(Deserialize)]
+struct GetRecipeParams {
+    id: Option<String>,
+    tags: Option<String>,
+}
 
-    let recipe_result = sqlx::query_as!(Recipe, "SELECT * FROM recipes ORDER BY RANDOM() LIMIT 1;")
-        .fetch_one(db)
+async fn tagged_recipe(db: &SqlitePool, tags: &str) -> Result<Option<String>, sqlx::Error> {
+    let mut tx = db.begin().await?;
+    sqlx::query("DROP TABLE IF EXISTS qtags;").execute(&mut *tx).await?;
+    sqlx::query("CREATE TEMPORARY TABLE qtags (tag VARCHR(200));")
+        .execute(&mut *tx)
+        .await?;
+    for tag in tags.split(',') {
+        sqlx::query("INSERT INTO qtags VALUES ($1);")
+            .bind(tag)
+            .execute(&mut *tx)
+            .await?;
+    }
+    let recipe_ids = sqlx::query("SELECT DISTINCT recipe_id FROM tags JOIN qtags ON tags.tag = qtags.tag ORDER BY RANDOM() LIMIT 1;")
+        .fetch_all(&mut *tx)
+        .await?;
+    let nrecipe_ids = recipe_ids.len();
+    let result = if nrecipe_ids == 1 {
+        Some(recipe_ids[0].get(0))
+    } else {
+        None
+    };
+    tx.commit().await?;
+
+    Ok(result)
+}
+
+async fn get_recipe(
+    State(app_state): State<Arc<RwLock<AppState>>>,
+    Query(params): Query<GetRecipeParams>
+    ) -> Result<response::Response, http::StatusCode> {
+    let mut app_state = app_state.write().await;
+    let db = app_state.db.clone();
+    
+    // User has passed the id in the params
+    if let GetRecipeParams { id: Some(id), .. } = params {
+        let recipe_result = sqlx::query_as!(Recipe, "SELECT * FROM recipes WHERE id = $1;", id)
+            .fetch_one(&db)
+            .await;
+        let result = match recipe_result {
+            Ok(recipe) => {
+                let mut tags =
+                    sqlx::query_scalar!("SELECT tag FROM tags WHERE recipe_id = $1;", recipe.id)
+                        .fetch(&db);
+                let mut tag_list: Vec<String> = Vec::new();
+                while let Some(tag) = tags.next().await {
+                    let tag = tag.unwrap_or_else(|e| {
+                        log::error!("tag fetch failed: {}", e);
+                        panic!("tag fetch failed")
+                    });
+                    tag_list.push(tag);
+                }
+                let tag_string = tag_list.join(", ");
+
+                app_state.current_recipe = recipe.clone();
+                let recipe = IndexTemplate::new(recipe.clone(), tag_string);
+                Ok(response::Html(recipe.to_string()).into_response())
+            }
+            Err(e) => {
+                log::warn!("recipe fetch failed: {}", e);
+                Err(http::StatusCode::NOT_FOUND)
+            }
+        };
+        return result;
+
+    }
+
+    // User passed tags in the params
+    if let GetRecipeParams { tags: Some(tags), .. } = params {
+        log::info!("recipe tags: {}", tags);
+
+        let mut tags_string = String::new();
+        for c in tags.chars() {
+            if c.is_alphabetic() || c == ',' {
+                let cl: String = c.to_lowercase().collect();
+                tags_string.push_str(&cl);
+            }
+        }
+
+        let recipe_result = tagged_recipe(&db, &tags_string).await;
+        match recipe_result {
+            Ok(Some(id)) => {
+                let uri = format!("/?id={}", id);
+                return Ok(response::Redirect::to(&uri).into_response());
+            }
+            Ok(None) => {
+                log::info!("tagged recipe selection was empty");
+            }
+            Err(e) => {
+                log::error!("tagged recipe selection database error: {}", e);
+                panic!("tagged recipe selection database error");
+            }
+        }
+
+    }
+
+    // Default to a random joke
+    let recipe_result = sqlx::query_scalar!("SELECT id FROM recipes ORDER BY RANDOM() LIMIT 1;")
+        .fetch_one(&db)
         .await;
-    let result = match recipe_result {
-        Ok(recipe) => {
-            app_state.current_recipe = recipe.clone();
-            let recipe = IndexTemplate::recipe(recipe.clone());
-            response::Html(recipe.to_string())
+
+    match recipe_result {
+        Ok(id) => {
+            let uri = format!("/?id={}", id);
+            Ok(response::Redirect::to(&uri).into_response())
         },
         Err(e) => {
-            log::warn!("recipe failed fetch one query: {}", e);
-            // Err(http::StatusCode::NOT_FOUND)
-            // FIXME: Currently setting default recipe
-            let recipe = IndexTemplate::recipe(app_state.current_recipe.clone());
-            response::Html(recipe.to_string())
+            log::error!("recipe failed fetch one query: {}", e);
+            panic!("recipe selection failed");
         }
-    };
-
-    return result;
-
+    }
 }
 
 async fn serve() -> Result<(), Box<dyn std::error::Error>> {
@@ -63,20 +157,41 @@ async fn serve() -> Result<(), Box<dyn std::error::Error>> {
     // let recipes = read_recipes("assets/static/recipes.json")?;
     if let Some(path) = args.init_from {
         let recipes = read_recipes(path)?;
-        let mut tx = db.begin().await?;
-        for r in &recipes {
-            sqlx::query!(
+    'next_recipe:
+        for rr in recipes {
+            let mut tx = db.begin().await?;
+            let (r, tags) = rr.to_recipe();
+            let recipe_insert = sqlx::query!(
                 "INSERT INTO recipes (id, title, ingredients, instructions, recipe_source) VALUES ($1, $2, $3, $4, $5);",
                 r.id,
                 r.title,
                 r.ingredients,
                 r.instructions,
-                r.source,
+                r.recipe_source,
             )
             .execute(&mut *tx)
-            .await?;
+            .await;
+            if let Err(e) = recipe_insert {
+                eprintln!("error: recipe insert: {}: {}", r.id, e);
+                tx.rollback().await?;
+                continue;
+            };
+            for t in tags {
+                let tag_insert = sqlx::query!(
+                    "INSERT INTO tags (recipe_id, tag) VALUES ($1, $2);",
+                    r.id,
+                    t,
+                )
+                .execute(&mut *tx)
+                .await;
+                if let Err(e) = tag_insert {
+                    eprintln!("error: tag insert: {} {}: {}", r.id, t, e);
+                    tx.rollback().await?;
+                    continue 'next_recipe;
+                };
+            }
+            tx.commit().await?;
         }
-        tx.commit().await?;
         return Ok(());
     }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -7,13 +7,15 @@ use askama::Template;
 pub struct IndexTemplate {
     recipe: Recipe,
     stylesheet: &'static str,
+    tags: String,
 }
 
 impl IndexTemplate {
-    pub fn recipe(recipe: Recipe) -> Self {
+    pub fn new(recipe: Recipe, tags: String) -> Self {
         Self {
             recipe,
             stylesheet: "/recipe.css",
+            tags,
         }
     }
 }


### PR DESCRIPTION
# Overview

This PR adds tags support to the server with an input form. A query string was added to the URL with the id of the recipe.

## Notes
```rust
    if let GetRecipeParams {
        tags: Some(tags), ..
    } = params { 
         // ops
    }
```

When using the HTML form if the tags input is blank it still triggers this block but since there is no tags we get:

```rust
  Ok(None) => {
      log::info!("tagged recipe selection was empty");
  }
```
Which in turn falls through to getting a random recipe.